### PR TITLE
Empty JSON object field values

### DIFF
--- a/src/main/scala/com/codahale/jerkson/deser/CaseClassDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/CaseClassDeserializer.scala
@@ -30,6 +30,10 @@ class CaseClassDeserializer(config: DeserializationConfig,
       jp.nextToken()
     }
 
+    if (jp.getCurrentToken == JsonToken.END_OBJECT) {
+      return null
+    }
+
     if (jp.getCurrentToken() != JsonToken.FIELD_NAME) {
       throw ctxt.mappingException(javaType.getRawClass)
     }

--- a/src/main/scala/com/codahale/jerkson/deser/JValueDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/JValueDeserializer.scala
@@ -23,7 +23,8 @@ class JValueDeserializer extends JsonDeserializer[Object] {
       }
       case JsonToken.START_OBJECT => {
         jp.nextToken()
-        deserialize(jp, ctxt)
+        if (jp.getCurrentToken == JsonToken.END_OBJECT) JObject(List.empty[JField])
+        else deserialize(jp, ctxt)
       }
       case JsonToken.FIELD_NAME => {
         val fields = new ArrayBuffer[JField]

--- a/src/main/scala/com/codahale/jerkson/deser/MapDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/MapDeserializer.scala
@@ -13,11 +13,15 @@ class MapDeserializer[CC[A, B] <: Map[A, B] with MapLike[A, B, CC[A, B]]](compan
                                                                           valueDeserializer: JsonDeserializer[Object])
   extends JsonDeserializer[Object] {
 
-  def deserialize(jp: JsonParser, ctxt: DeserializationContext) = {
+  def deserialize(jp: JsonParser, ctxt: DeserializationContext):Object = {
     val builder = companion.newBuilder[String, Object]
 
     if (jp.getCurrentToken == JsonToken.START_OBJECT) {
       jp.nextToken()
+    }
+
+    if (jp.getCurrentToken == JsonToken.END_OBJECT) {
+      return builder.result
     }
 
     if (jp.getCurrentToken() != JsonToken.FIELD_NAME) {


### PR DESCRIPTION
As far as I can tell, empty objects are legal possible field values. Jackson handles them fine, but jerkson currently throws an exception when it encounters them. An example JSON document that causes this behavior: `{"foo":{}}`. I don't think my fix is comprehensive - perhaps `OptionDeserializer` should account for this as well?
