### PR TITLE
Development

### DIFF
--- a/src/test/scala/com/codahale/jerkson/tests/JsonParsingSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/JsonParsingSpec.scala
@@ -170,6 +170,12 @@ object JsonParsingSpec extends Spec {
     }
   }
 
+  class `Parsing an empty JSON object` {
+    def `should be readable as a Map[String, String]` {
+      parse[Map[String, String]]("{}") must beEqualTo(Map())
+    }
+  }
+
   class `Parsing a JSON object with int field values` {
     def `should be readable as a Map[String, Int]` {
       parse[Map[String, Int]](""" {"one":1, "two": 2} """) must beEqualTo(Map("one" -> 1,


### PR DESCRIPTION
I found a case where Jerkson is tossing an "Invalid JSON" exception when trying to parse an empty object ("{}"). I discovered this when trying to parse a case class with an empty Map[String,String] contained within. But it appears to affect standalone JSON objects as well.

Haven't had a chance to dig in to figure out what's wrong. Just wanted to get the test committed so it's a known issue.
