### PR TITLE
Added ScalaSigUtil helper object borrowed from Salat, so that it would wo

### DIFF
--- a/src/main/scala/com/codahale/jerkson/util/CaseClassSigParser.scala
+++ b/src/main/scala/com/codahale/jerkson/util/CaseClassSigParser.scala
@@ -17,14 +17,14 @@ object CaseClassSigParser {
   val BYTES_VALUE = "bytes"
 
   protected def parseScalaSig[A](clazz: Class[A]): Option[ScalaSig] = {
-    val firstPass = ScalaSigParser.parse(clazz)
+    val firstPass = ScalaSigUtil.parse(clazz)
     firstPass match {
       case Some(x) => {
         Some(x)
       }
       case None if clazz.getName.endsWith("$") => {
         val clayy = Class.forName(clazz.getName.replaceFirst("\\$$", ""))
-        val secondPass = ScalaSigParser.parse(clayy)
+        val secondPass = ScalaSigUtil.parse(clayy)
         secondPass
       }
       case x => x

--- a/src/main/scala/com/codahale/jerkson/util/ScalaSigUtil.scala
+++ b/src/main/scala/com/codahale/jerkson/util/ScalaSigUtil.scala
@@ -1,0 +1,58 @@
+package com.codahale.jerkson.util
+
+import com.codahale.jerkson.util.scalax.rules.scalasig._
+import java.lang.annotation.Annotation
+import java.lang.reflect.AnnotatedElement
+import reflect.ScalaSignature
+import reflect.generic.ByteCodecs
+
+/** This is a helper object borrowed from Salat that looks up the Scala signature
+  * from the classfile object's attribute first before looking for the .class
+  * file and parsing bytecode from there to be able to work with the Play framework. */
+object ScalaSigUtil {
+
+  implicit def whatever2annotated(x: Any) = new PimpedAnnotatedElement(x)
+
+  class PimpedAnnotatedElement(x: Any) {
+    def annotation[A <: Annotation : Manifest]: Option[A] =
+      x match {
+        case x: AnnotatedElement if x != null => x.getAnnotation[A](manifest[A].erasure.asInstanceOf[Class[A]]) match {
+          case a if a != null => Some(a)
+          case _ => None
+        }
+        case _ => None
+      }
+
+    def annotated_?[A <: Annotation : Manifest]: Boolean = annotation[A](manifest[A]).isDefined
+  }
+
+  private def parseClassFileFromByteCode(clazz: Class[_]): Option[ClassFile] = try {
+    // taken from ScalaSigParser parse method with the explicit purpose of walking away from NPE
+    val byteCode  = ByteCode.forClass(clazz)
+    Option(ClassFileParser.parse(byteCode))
+  }
+  catch {
+    case e: NullPointerException => None  // yes, this is the exception, but it is totally unhelpful to the end user
+  }
+
+  private def parseByteCodeFromAnnotation(clazz: Class[_]): Option[ByteCode] = {
+    clazz.annotation[ScalaSignature] match {
+      case Some(sig) if sig != null => {
+        val bytes = sig.bytes.getBytes("UTF-8")
+        val len = ByteCodecs.decode(bytes)
+        Option(ByteCode(bytes.take(len)))
+      }
+      case _ => None
+    }
+  }
+
+  def parse(_clazz: Class[_]): Option[ScalaSig] = {
+    // support case objects by selectively re-jiggering the class that has been passed in
+    val clazz = if (_clazz.getName.endsWith("$")) Class.forName(_clazz.getName.replaceFirst("\\$$", "")) else _clazz
+    assume(clazz != null, "parse: cannot parse ScalaSig from null class=%s".format(_clazz))
+
+    parseClassFileFromByteCode(clazz).map(ScalaSigParser.parse(_)).getOrElse(None) orElse
+    parseByteCodeFromAnnotation(clazz).map(ScalaSigAttributeParsers.parse(_)) orElse
+    None
+  }
+}


### PR DESCRIPTION
Added ScalaSigUtil helper object borrowed from Salat, so that it would work in a Play webserver without a NullPointerException.

This is for deserializing case classes within Play.  It first looks for the ScalaSig attribute (present since Scala 2.8.0) in the ClassFile bytes before trying to load the .classfile from the classpath.  This solved Salat's problem to:

http://groups.google.com/group/play-framework/browse_thread/thread/988bf4bb0b3b4a22
http://groups.google.com/group/scala-salat/browse_thread/thread/60593febe2d8312f

And I've verified to work too with Jerkson in Play. 

It was a bit hard for me to run your Specs, it didn't compile even after I downloaded all the dependencies.  Perhaps you could publish the SBT project for them if that's what you used?

Thanks!
