### PR TITLE
CaseClassSerializer should also ignore 'transient' fields.

### DIFF
--- a/src/main/scala/com/codahale/jerkson/ser/CaseClassSerializer.scala
+++ b/src/main/scala/com/codahale/jerkson/ser/CaseClassSerializer.scala
@@ -8,7 +8,9 @@ import org.codehaus.jackson.map.annotate.JsonCachable
 @JsonCachable
 class CaseClassSerializer[A <: Product](klass: Class[_]) extends JsonSerializer[A] {
   private val nonIgnoredFields = klass.getDeclaredFields.filterNot { f =>
-    f.getAnnotation(classOf[JsonIgnore]) != null || f.getName.contains("$")
+    f.getAnnotation(classOf[JsonIgnore]) != null ||
+      f.getAnnotation(classOf[transient]) != null ||
+      f.getName.contains("$")
   }
 
   private val methods = klass.getDeclaredMethods

--- a/src/main/scala/com/codahale/jerkson/ser/CaseClassSerializer.scala
+++ b/src/main/scala/com/codahale/jerkson/ser/CaseClassSerializer.scala
@@ -4,12 +4,13 @@ import org.codehaus.jackson.JsonGenerator
 import org.codehaus.jackson.map.{SerializerProvider, JsonSerializer}
 import org.codehaus.jackson.annotate.JsonIgnore
 import org.codehaus.jackson.map.annotate.JsonCachable
+import java.lang.reflect.Modifier
 
 @JsonCachable
 class CaseClassSerializer[A <: Product](klass: Class[_]) extends JsonSerializer[A] {
   private val nonIgnoredFields = klass.getDeclaredFields.filterNot { f =>
     f.getAnnotation(classOf[JsonIgnore]) != null ||
-      f.getAnnotation(classOf[transient]) != null ||
+      (f.getModifiers & Modifier.TRANSIENT) != 0 ||
       f.getName.contains("$")
   }
 

--- a/src/test/scala/com/codahale/jerkson/tests/CaseClassSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/CaseClassSupportSpec.scala
@@ -62,6 +62,22 @@ class CaseClassSupportSpec extends Spec {
     }
   }
 
+  class `A case class with transient members` {
+    @test def `generates a JSON object without those fields` = {
+      generate(CaseClassWithTransientField(1)) must beEqualTo("""{"id":1}""")
+    }
+
+    @test def `is parsable from a JSON object without those fields` = {
+      parse[CaseClassWithTransientField]("""{"id":1}""") must
+        beEqualTo(CaseClassWithTransientField(1))
+    }
+
+    @test def `is not parsable from a JSON object which doesn't include all of the matching fields` = {
+      parse[CaseClassWithTransientField]("""{}""") must
+        throwA[ParsingException]("""Invalid JSON. Needed \[id], but found \[\].""")
+    }
+  }
+
   class `A case class with an overloaded field` {
     @test def `generates a JSON object with the nullary version of that field` = {
       generate(CaseClassWithOverloadedField(1)) must beEqualTo("""{"id":1}""")

--- a/src/test/scala/com/codahale/jerkson/tests/ExampleCaseClasses.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/ExampleCaseClasses.scala
@@ -13,6 +13,10 @@ case class CaseClassWithIgnoredField(id: Long) {
   @JsonIgnore
   val uncomfortable = "Bad Touch"
 }
+case class CaseClassWithTransientField(id: Long) {
+  @transient
+  val lol = "I'm sure it's just a phase."
+}
 
 case class CaseClassWithOverloadedField(id: Long) {
   def id(prefix: String): String = prefix + id


### PR DESCRIPTION
Hi Coda,

At https://github.com/codahale/jerkson/blob/development/src/main/scala/com/codahale/jerkson/ser/CaseClassSerializer.scala, I saw it was possible to ignore fields by adding the `@JsonIgnore` annotation.    This is fine as long as I don't extend any classes I can't edit.  

Please consider this patch which modifies CaseClassSerializer to also ignore fields which have the `@scala.transient` annotation.  Many libraries existing use this standard annotation on their datastructures (and I inherit from them, so I'm getting stray fields in my JSON). Thanks!
