### PR TITLE
Making it possible to set a custom classloader

### DIFF
--- a/src/main/scala/com/codahale/jerkson/util/CaseClassSigParser.scala
+++ b/src/main/scala/com/codahale/jerkson/util/CaseClassSigParser.scala
@@ -17,6 +17,11 @@ object CaseClassSigParser {
   val SCALA_SIG = "ScalaSig"
   val SCALA_SIG_ANNOTATION = "Lscala/reflect/ScalaSignature;"
   val BYTES_VALUE = "bytes"
+  var classLoader: ClassLoader = getClass.getClassLoader
+
+  def setClassLoader(cl: ClassLoader) {
+    classLoader = cl
+  }
 
   private def parseClassFileFromByteCode(clazz: Class[_]): Option[ClassFile] = try {
     // taken from ScalaSigParser parse method with the explicit purpose of walking away from NPE
@@ -46,7 +51,7 @@ object CaseClassSigParser {
   }
 
   protected def findRootClass(klass: Class[_]) =
-    Class.forName(klass.getName.split("\\$").head)
+    classLoader.loadClass(klass.getName.split("\\$").head)
 
   protected def simpleName(klass: Class[_]) =
     klass.getName.split("\\$").last
@@ -137,6 +142,6 @@ object CaseClassSigParser {
     case "scala.Char" => classOf[java.lang.Character]
     case "scala.Any" => classOf[Any]
     case "scala.AnyRef" => classOf[AnyRef]
-    case name => Class.forName(name)
+    case name => classLoader.loadClass(name)
   }
 }


### PR DESCRIPTION
Making it possible to set an alternative classloader. This is necessary in environments like e.g. the Play framework, where it would be done like so:

```
CaseClassSigParser.setClassLoader(play.Play.classloader)
```

Perhaps there is a better place where to set such things but I have not found where.

Also it looks like Jackson has an extension point through the ObjectMapper to set a custom classloader (see http://jira.codehaus.org/browse/JACKSON-527) but I have my doubts as to where to get a hold on the (shared) ObjectMapper for a case like this.
