### PR TITLE
Better constructor lookup for case classes

### DIFF
--- a/src/main/scala/com/codahale/jerkson/deser/CaseClassDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/CaseClassDeserializer.scala
@@ -13,8 +13,12 @@ import org.codehaus.jackson.map.annotate.JsonCachable
 class CaseClassDeserializer(config: DeserializationConfig,
                             javaType: JavaType,
                             provider: DeserializerProvider) extends JsonDeserializer[Object] {
-  require(javaType.getRawClass.getConstructors.length == 1, "Case classes must only have one constructor.")
-  private val constructor = javaType.getRawClass.getConstructors.head
+//  require(javaType.getRawClass.getConstructors.length == 1, "Case classes must only have one constructor.")
+  
+  private val constructor = {
+    val constructors = javaType.getRawClass.getConstructors.asInstanceOf[Array[java.lang.reflect.Constructor[AnyRef]]]
+    (constructors(0) /: constructors) { (a: java.lang.reflect.Constructor[AnyRef], b: java.lang.reflect.Constructor[AnyRef]) => if(a.getParameterTypes.length > b.getParameterTypes.length) a else b }
+  }
   private val params = CaseClassSigParser.parse(javaType.getRawClass, config.getTypeFactory).toArray
 
   def deserialize(jp: JsonParser, ctxt: DeserializationContext): Object = {


### PR DESCRIPTION
Right now, there is a limitation which makes the serialization of case classes with more than one constructor impossible. This is inconvenient in cases where case classes need to have more than one constructor, e.g. in the (yet again) case of the Play framework where it is possible to load data from a YML file into a java bean / case class and the library that does so requires an empty constructor.

I would suggest the following approaches to be allowed:
- by default use the longest constructor (I think this is the approach that lift-json takes, and I'd say it makes sense)
- if present, use the constructor annotated with @JsonConstructor (http://jackson.codehaus.org/1.0.1/javadoc/org/codehaus/jackson/annotate/JsonCreator.html)

The pull request contains a suggested implementation for the "longest constructor" proposal.
