### PR TITLE
Implement case class default parameters

### DIFF
--- a/src/test/scala/com/codahale/jerkson/tests/CaseClassSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/CaseClassSupportSpec.scala
@@ -27,6 +27,13 @@ class CaseClassSupportSpec extends Spec {
     }
   }
 
+  class `A case class with a default field` {
+    @Test def `is parsable from an incomplete JSON object` = {
+      parse[CaseClassWithDefaultString]("""{"id":1}""").must(be(CaseClassWithDefaultString(1, "Coda")))
+      parse[CaseClassWithDefaultInt]("""{"id":1}""").must(be(CaseClassWithDefaultInt(1, 42)))
+    }
+  }
+
   class `A case class with lazy fields` {
     @Test def `generates a JSON object with those fields evaluated` = {
       generate(CaseClassWithLazyVal(1)).must(be("""{"id":1,"woo":"yeah"}"""))

--- a/src/test/scala/com/codahale/jerkson/tests/ExampleCaseClasses.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/ExampleCaseClasses.scala
@@ -6,6 +6,9 @@ import com.codahale.jerkson.JsonSnakeCase
 
 case class CaseClass(id: Long, name: String)
 
+case class CaseClassWithDefaultString(id: Long, name: String = "Coda")
+case class CaseClassWithDefaultInt(id: Long, answer: Int = 42)
+
 case class CaseClassWithLazyVal(id: Long) {
   lazy val woo = "yeah"
 }


### PR DESCRIPTION
(as discussed via email)

You have your domain stuff as case classes with default parameters,
e.g. case class Message(msg: String, priority: String = "low")
So, Message(msg="hey") will have a default low priority.

Now you can send something like this on the messaging infrastructure:

{
 "msg" : "Hello, World!"
}

...and the serializer in your message converter won't complain about
the lack of priority flag, and will serialize a Message with "low"
priority.
