### PR TITLE
Add support for Symbol and Map[Symbol, _]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,8 @@
                         <arg>-optimise</arg>
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
+                        <arg>-Xmax-classfile-name</arg>
+                        <arg>130</arg>
                     </args>
                     <compilerPlugins>
                         <compilerPlugin>

--- a/src/main/scala/com/codahale/jerkson/deser/ImmutableSymbolMapDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/ImmutableSymbolMapDeserializer.scala
@@ -7,7 +7,7 @@ import org.codehaus.jackson.map.annotate.JsonCachable
 
 /** Deserializes a Map indexed by a Scala Symbol */
 @JsonCachable
-class SymbolMapDeserializer (valueType: JavaType,
+class ImmutableSymbolMapDeserializer (valueType: JavaType,
                              valueDeserializer: JsonDeserializer[Object]) extends JsonDeserializer[Object] {
   def deserialize(jp: JsonParser, ctxt: DeserializationContext) = {
     var map = Map.empty[Symbol, Object]

--- a/src/main/scala/com/codahale/jerkson/deser/MutableSymbolLinkedHashMapDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/MutableSymbolLinkedHashMapDeserializer.scala
@@ -1,0 +1,28 @@
+package com.codahale.jerkson.deser
+
+import org.codehaus.jackson.map.annotate.JsonCachable
+import org.codehaus.jackson.`type`.JavaType
+import org.codehaus.jackson.map.{DeserializationContext, JsonDeserializer}
+import scala.collection.mutable
+import org.codehaus.jackson.{JsonToken, JsonParser}
+
+@JsonCachable
+class MutableSymbolLinkedHashMapDeserializer(valueType: JavaType,
+                                             valueDeserializer: JsonDeserializer[Object]) extends JsonDeserializer[Object] {
+  def deserialize(jp: JsonParser, ctxt: DeserializationContext) = {
+    val builder = mutable.LinkedHashMap.newBuilder[Symbol, Object]
+
+    if (jp.getCurrentToken == JsonToken.START_OBJECT) {
+      jp.nextToken()
+    }
+
+    while (jp.getCurrentToken != JsonToken.END_OBJECT) {
+      val name = Symbol(jp.getCurrentName)
+      jp.nextToken()
+      builder += ((name, valueDeserializer.deserialize(jp, ctxt)))
+      jp.nextToken()
+    }
+
+    builder.result()
+  }
+}

--- a/src/main/scala/com/codahale/jerkson/deser/MutableSymbolMapDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/MutableSymbolMapDeserializer.scala
@@ -1,0 +1,33 @@
+package com.codahale.jerkson.deser
+
+import org.codehaus.jackson.map.annotate.JsonCachable
+import org.codehaus.jackson.`type`.JavaType
+import org.codehaus.jackson.map.{DeserializationContext, JsonDeserializer}
+import org.codehaus.jackson.{JsonToken, JsonParser}
+import scala.collection.mutable
+
+@JsonCachable
+class MutableSymbolMapDeserializer(valueType: JavaType,
+                                   valueDeserializer: JsonDeserializer[Object]) extends JsonDeserializer[Object] {
+  def deserialize(jp: JsonParser, ctxt: DeserializationContext) = {
+    val builder = mutable.HashMap.newBuilder[Symbol, Object]
+
+    if (jp.getCurrentToken == JsonToken.START_OBJECT) {
+      jp.nextToken()
+    }
+
+    if (jp.getCurrentToken != JsonToken.FIELD_NAME &&
+      jp.getCurrentToken != JsonToken.END_OBJECT) {
+      throw ctxt.mappingException(valueType.getRawClass)
+    }
+
+    while (jp.getCurrentToken != JsonToken.END_OBJECT) {
+      val name = Symbol(jp.getCurrentName)
+      jp.nextToken()
+      builder += ((name, valueDeserializer.deserialize(jp, ctxt)))
+      jp.nextToken()
+    }
+
+    builder.result()
+  }
+}

--- a/src/main/scala/com/codahale/jerkson/deser/ScalaDeserializers.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/ScalaDeserializers.scala
@@ -15,6 +15,8 @@ class ScalaDeserializers(classLoader: ClassLoader) extends Deserializers.Base {
       new RangeDeserializer
     } else if (klass == classOf[StringBuilder]) {
       new StringBuilderDeserializer
+    } else if (klass == classOf[Symbol]) {
+      new SymbolDeserializer
     } else if (klass == classOf[List[_]] || klass == classOf[immutable.List[_]]) {
       createSeqDeserializer(config, javaType, List, provider, property)
     } else if (klass == classOf[Seq[_]] || klass == classOf[immutable.Seq[_]] ||

--- a/src/main/scala/com/codahale/jerkson/deser/ScalaDeserializers.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/ScalaDeserializers.scala
@@ -124,6 +124,8 @@ class ScalaDeserializers(classLoader: ClassLoader) extends Deserializers.Base {
     val deserializer = provider.findTypedValueDeserializer(config, valueType, property)
     if (keyType.getRawClass == classOf[String]) {
       new ImmutableMapDeserializer[CC](companion, valueType, deserializer)
+    } else if (keyType.getRawClass == classOf[Symbol]) {
+      new SymbolMapDeserializer(valueType, deserializer)
     } else if (keyType.getRawClass == classOf[Int] || keyType.getRawClass == classOf[java.lang.Integer]) {
       new IntMapDeserializer(valueType, deserializer)
     } else if (keyType.getRawClass == classOf[Long] || keyType.getRawClass == classOf[java.lang.Long]) {

--- a/src/main/scala/com/codahale/jerkson/deser/ScalaDeserializers.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/ScalaDeserializers.scala
@@ -72,6 +72,9 @@ class ScalaDeserializers(classLoader: ClassLoader) extends Deserializers.Base {
       if (javaType.containedType(0).getRawClass == classOf[String]) {
         val valueType = javaType.containedType(1)
         new MutableMapDeserializer(valueType, provider.findTypedValueDeserializer(config, valueType, property))
+      } else if (javaType.containedType(0).getRawClass == classOf[Symbol]) {
+        val valueType = javaType.containedType(1)
+        new MutableSymbolMapDeserializer(valueType, provider.findTypedValueDeserializer(config, valueType, property))
       } else {
         null
       }
@@ -79,6 +82,9 @@ class ScalaDeserializers(classLoader: ClassLoader) extends Deserializers.Base {
       if (javaType.containedType(0).getRawClass == classOf[String]) {
         val valueType = javaType.containedType(1)
         new MutableLinkedHashMapDeserializer(valueType, provider.findTypedValueDeserializer(config, valueType, property))
+      } else if (javaType.containedType(0).getRawClass == classOf[Symbol]) {
+        val valueType = javaType.containedType(1)
+        new MutableSymbolLinkedHashMapDeserializer(valueType, provider.findTypedValueDeserializer(config, valueType, property))
       } else {
         null
       }
@@ -125,7 +131,7 @@ class ScalaDeserializers(classLoader: ClassLoader) extends Deserializers.Base {
     if (keyType.getRawClass == classOf[String]) {
       new ImmutableMapDeserializer[CC](companion, valueType, deserializer)
     } else if (keyType.getRawClass == classOf[Symbol]) {
-      new SymbolMapDeserializer(valueType, deserializer)
+      new ImmutableSymbolMapDeserializer(valueType, deserializer)
     } else if (keyType.getRawClass == classOf[Int] || keyType.getRawClass == classOf[java.lang.Integer]) {
       new IntMapDeserializer(valueType, deserializer)
     } else if (keyType.getRawClass == classOf[Long] || keyType.getRawClass == classOf[java.lang.Long]) {

--- a/src/main/scala/com/codahale/jerkson/deser/SymbolDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/SymbolDeserializer.scala
@@ -1,0 +1,16 @@
+package com.codahale.jerkson.deser
+
+import org.codehaus.jackson.map.annotate.JsonCachable
+import org.codehaus.jackson.map.{DeserializationContext, JsonDeserializer}
+import org.codehaus.jackson.{JsonToken, JsonParser}
+
+@JsonCachable
+class SymbolDeserializer extends JsonDeserializer[Object] {
+  def deserialize(jp: JsonParser, ctxt: DeserializationContext) = {
+    if (jp.getCurrentToken != JsonToken.VALUE_STRING) {
+      throw ctxt.mappingException(classOf[Symbol])
+    }
+
+    Symbol(jp.getText)
+  }
+}

--- a/src/main/scala/com/codahale/jerkson/deser/SymbolMapDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/SymbolMapDeserializer.scala
@@ -1,0 +1,37 @@
+package com.codahale.jerkson.deser
+
+import org.codehaus.jackson.`type`.JavaType
+import org.codehaus.jackson.map.{DeserializationContext, JsonDeserializer}
+import org.codehaus.jackson.{JsonToken, JsonParser}
+import org.codehaus.jackson.map.annotate.JsonCachable
+
+/** Deserializes a Map indexed by a Scala Symbol */
+@JsonCachable
+class SymbolMapDeserializer (valueType: JavaType,
+                             valueDeserializer: JsonDeserializer[Object]) extends JsonDeserializer[Object] {
+  def deserialize(jp: JsonParser, ctxt: DeserializationContext) = {
+    var map = Map.empty[Symbol, Object]
+
+    if (jp.getCurrentToken == JsonToken.START_OBJECT) {
+      jp.nextToken()
+    }
+
+    if (jp.getCurrentToken != JsonToken.FIELD_NAME &&
+      jp.getCurrentToken != JsonToken.END_OBJECT) {
+      throw ctxt.mappingException(valueType.getRawClass)
+    }
+
+    while (jp.getCurrentToken != JsonToken.END_OBJECT) {
+      try {
+        val name = Symbol(jp.getCurrentName)
+        jp.nextToken()
+        map += ((name, valueDeserializer.deserialize(jp, ctxt)))
+        jp.nextToken()
+      } catch {
+        case e: IllegalArgumentException => throw ctxt.mappingException(classOf[Symbol])
+      }
+    }
+
+    map
+  }
+}

--- a/src/main/scala/com/codahale/jerkson/ser/MapSerializer.scala
+++ b/src/main/scala/com/codahale/jerkson/ser/MapSerializer.scala
@@ -9,7 +9,13 @@ class MapSerializer extends JsonSerializer[collection.Map[_ ,_]] {
   def serialize(map: collection.Map[_,_], json: JsonGenerator, provider: SerializerProvider) {
     json.writeStartObject()
     for ((key, value) <- map) {
-      provider.defaultSerializeField(key.toString, value, json)
+      // TODO: Generalize to avoid special-casing
+      val field = key match {
+        case Symbol(name) => name
+        case _ => key.toString
+      }
+
+      provider.defaultSerializeField(field, value, json)
     }
     json.writeEndObject()
   }

--- a/src/main/scala/com/codahale/jerkson/ser/ScalaSerializers.scala
+++ b/src/main/scala/com/codahale/jerkson/ser/ScalaSerializers.scala
@@ -10,6 +10,8 @@ class ScalaSerializers extends Serializers.Base {
         new OptionSerializer
     } else if (classOf[StringBuilder].isAssignableFrom(beanDesc.getBeanClass)) {
       new StringBuilderSerializer
+    } else if (classOf[Symbol].isAssignableFrom(beanDesc.getBeanClass)) {
+      new SymbolSerializer
     } else if (classOf[collection.Map[_,_]].isAssignableFrom(beanDesc.getBeanClass)) {
       new MapSerializer
     } else if (classOf[Range].isAssignableFrom(beanDesc.getBeanClass)) {

--- a/src/main/scala/com/codahale/jerkson/ser/SymbolSerializer.scala
+++ b/src/main/scala/com/codahale/jerkson/ser/SymbolSerializer.scala
@@ -1,0 +1,12 @@
+package com.codahale.jerkson.ser
+
+import org.codehaus.jackson.JsonGenerator
+import org.codehaus.jackson.map.{SerializerProvider, JsonSerializer}
+import org.codehaus.jackson.map.annotate.JsonCachable
+
+@JsonCachable
+class SymbolSerializer extends JsonSerializer[Symbol] {
+  def serialize(value: Symbol, json: JsonGenerator, provider: SerializerProvider) {
+    json.writeString(value.name)
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/BasicTypeSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/BasicTypeSupportSpec.scala
@@ -114,6 +114,16 @@ class BasicTypeSupportSpec extends Spec {
       parse[StringBuilder]("\"foo\"").toString().must(be("foo"))
     }
   }
+  
+  class `A Symbol` {
+    @Test def `generates a JSON string` = {
+      generate(Symbol("foo")).must(be("\"foo\""))
+    }
+    
+    @Test def `is parsable from a JsonNode string` = {
+      parse[Symbol]("\"foo\"").name.must(be("foo"))
+    }
+  }
 
   class `A null Object` {
     @Test def `generates a JSON null` = {

--- a/src/test/scala/com/codahale/jerkson/tests/ImmutableCollectionSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/ImmutableCollectionSupportSpec.scala
@@ -156,6 +156,26 @@ class ImmutableCollectionSupportSpec extends Spec {
       }.must(throwA[ParsingException])
     }
   }
+  
+  class `An immutable.HashMap[Symbol, Any]` {
+    @Test def `generates a JSON object` = {
+      generate(HashMap[Symbol, Any]('one -> 1)).must(be("""{"one":1}"""))
+    }
+    
+    @Test def `is parsable from a JSON object with int field values` = {
+      parse[HashMap[Symbol, Any]]("""{"one":1}""").must(be(HashMap('one -> 1)))
+    }
+    
+    @Test def `is parsable from an empty JSON object` = {
+      parse[HashMap[Symbol, Any]]("{}").must(be(HashMap.empty[Symbol, Any]))
+    }
+    
+    @Test def `is not parsable from an empty JSON object in a JSON array` = {
+      evaluating {
+        parse[HashMap[Symbol, Any]]("[{}]")
+      }.must(throwA[ParsingException])
+    }
+  }
 
   class `An immutable.Map[Int, String]` {
     @Test def `generates a JSON object` = {

--- a/src/test/scala/com/codahale/jerkson/tests/MutableCollectionSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/MutableCollectionSupportSpec.scala
@@ -186,4 +186,55 @@ class MutableCollectionSupportSpec extends Spec {
       parse[LinkedHashMap[String, Int]]("{}").must(be(LinkedHashMap.empty[String, Int]))
     }
   }
+
+  class `A mutable.Map[Symbol, Int]` {
+    @Test def `generates a JSON object` = {
+      generate(Map('one -> 1)).must(be("""{"one":1}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field values` = {
+      parse[Map[Symbol, Int]]("""{"one":1}""").must(be(Map('one -> 1)))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[Map[Symbol, Int]]("{}").must(be(Map.empty[Symbol, Int]))
+    }
+  }
+
+  class `A mutable.Map[Symbol, Any]` {
+    @Test def `is not parsable from an empty JSON object in a JSON array` = {
+      evaluating {
+        parse[Map[Symbol, Any]]("[{}]")
+      }.must(throwA[ParsingException])
+    }
+  }
+
+  class `A mutable.HashMap[Symbol, Int]` {
+    @Test def `generates a JSON object` = {
+      generate(HashMap('one -> 1)).must(be("""{"one":1}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field values` = {
+      parse[HashMap[Symbol, Int]]("""{"one":1}""").must(be(HashMap('one -> 1)))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[HashMap[Symbol, Int]]("{}").must(be(HashMap.empty[Symbol, Int]))
+    }
+  }
+
+  class `A mutable.LinkedHashMap[Symbol, Int]` {
+    @Test def `generates a JSON object` = {
+      generate(LinkedHashMap('one -> 1)).must(be("""{"one":1}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field values` = {
+      println(parse[LinkedHashMap[Symbol, Int]]("""{"one":1}"""))
+      parse[LinkedHashMap[Symbol, Int]]("""{"one":1}""").must(be(LinkedHashMap('one -> 1)))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[LinkedHashMap[Symbol, Int]]("{}").must(be(LinkedHashMap.empty[Symbol, Int]))
+    }
+  }
 }


### PR DESCRIPTION
Symbols are Strings that are guaranteed to be interned. They're especially useful as Map keys as they allow constant-time equality checks (improving collection search performance) and ensure recurring field names are shared, reducing load on the old-gen considerably when working with large numbers of long lived Maps.

I'm not too happy about all the special-cased Map Deserializers - I feel that this could probably be generalized somewhat, certainly for String vs. Symbol keys.

Similarly, I'm sure the implementation for MapSerializer can be more generic, but I didn't want to be too invasive.
