### PR TITLE
Add support for parsing null values inside JSON arrays

### DIFF
--- a/src/main/scala/com/codahale/jerkson/deser/EitherDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/EitherDeserializer.scala
@@ -17,7 +17,13 @@ class EitherDeserializer(config: DeserializationConfig,
     try {
       Left(tp.getCodec.readValue[Object](tp, javaType.containedType(0)))
     } catch {
-      case _ => Right(tp.getCodec.readValue[Object](tp, javaType.containedType(1)))
+      case _ => {
+        // We don't want to reuse the same parser that was used in the
+        // try-block, as the read there may have used nextToken() and advanced
+        // us past the point where we expect to be.
+        val tpRight = new TreeTraversingParser(node, jp.getCodec)
+        Right(tpRight.getCodec.readValue[Object](tpRight, javaType.containedType(1)))
+      }
     }
   }
 }

--- a/src/main/scala/com/codahale/jerkson/deser/JValueDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/JValueDeserializer.scala
@@ -16,6 +16,7 @@ class JValueDeserializer(factory: TypeFactory, klass: Class[_]) extends JsonDese
     }
 
     val value = jp.getCurrentToken match {
+      case JsonToken.VALUE_NULL => JNull
       case JsonToken.VALUE_NUMBER_INT => JInt(BigInt(jp.getText))
       case JsonToken.VALUE_NUMBER_FLOAT => JFloat(jp.getDoubleValue)
       case JsonToken.VALUE_STRING => JString(jp.getText)

--- a/src/test/scala/com/codahale/jerkson/tests/ASTTypeSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/ASTTypeSupportSpec.scala
@@ -61,6 +61,10 @@ class ASTTypeSupportSpec extends Spec {
     @Test def `is parsable from a JSON null as a JValue` = {
       parse[JValue]("null").must(be(JNull))
     }
+
+    @Test def `is parsable from an embedded JSON null as a JValue` = {
+      parse[JValue]("[null]").must(be(JArray(List(JNull))))
+    }
   }
 
   class `An AST.JBoolean` {

--- a/src/test/scala/com/codahale/jerkson/tests/EitherSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/EitherSupportSpec.scala
@@ -1,0 +1,33 @@
+package com.codahale.jerkson.tests
+
+import com.codahale.jerkson.Json._
+import com.codahale.simplespec.Spec
+import com.codahale.jerkson.ParsingException
+import org.codehaus.jackson.node.IntNode
+import org.junit.Test
+
+class EitherSupportSpec extends Spec {
+  class `An Either of two case classes` {
+    @Test def `is parseable when the Left is used` = {
+      val e = parse[Either[CaseClassWithArrays, CaseClass]]("""{"one": "a", "two": [ "b", "c" ], "three": [ 0, 1 ]}""")
+
+      e.isLeft.must(be(true))
+
+      val c = e.left.get
+      c.one.must(be("a"))
+      c.two.must(be(Array[String]("b", "c")))
+      c.three.must(be(Array[Int](0, 1)))
+    }
+
+    @Test def `is parseable when the Right is used` = {
+      val e = parse[Either[CaseClass, CaseClassWithArrays]]("""{"one": "a", "two": [ "b", "c" ], "three": [ 0, 1 ]}""")
+
+      e.isRight.must(be(true))
+
+      val c = e.right.get
+      c.one.must(be("a"))
+      c.two.must(be(Array[String]("b", "c")))
+      c.three.must(be(Array[Int](0, 1)))
+    }
+  }
+}


### PR DESCRIPTION
General fix for issue #Num: #41 (Parsing null in array fails for JValue).

Works with existing tests, although it still seems unlikely that the `JsonToken.VALUE_NULL` case in the pattern match was unintentionally omitted.
