### PR TITLE
For issue #45 (Support for parameterized types)

### DIFF
--- a/src/main/scala/com/codahale/jerkson/deser/CaseClassDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/CaseClassDeserializer.scala
@@ -17,7 +17,7 @@ class CaseClassDeserializer(config: DeserializationConfig,
                             provider: DeserializerProvider,
                             classLoader: ClassLoader) extends JsonDeserializer[Object] {
   private val isSnakeCase = javaType.getRawClass.isAnnotationPresent(classOf[JsonSnakeCase])
-  private val params = CaseClassSigParser.parse(javaType.getRawClass, config.getTypeFactory, classLoader).map {
+  private val params = CaseClassSigParser.parse(javaType, config.getTypeFactory, classLoader).map {
     case (name, jt) => (if (isSnakeCase) snakeCase(name) else name, jt)
   }.toArray
   private val paramTypes = params.map { _._2.getRawClass }.toList

--- a/src/test/scala/com/codahale/jerkson/tests/CaseClassSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/CaseClassSupportSpec.scala
@@ -236,4 +236,19 @@ class CaseClassSupportSpec extends Spec {
       ))
     }
   }
+
+  class `A parameterized case class` {
+    @Test def `is parsable from a JSON object` = {
+      val c = parse[CaseClassWithParameter[Int]]("""{"id":"1","list":[2,3]}""")
+
+      c.id.must(be(1))
+      c.list.must(be(List(2,3)))
+    }
+
+    @Test def `generates a JSON object` = {
+      generate(CaseClassWithParameter[Int](1, List(2, 3))).must(be(
+        """{"id":1,"list":[2,3]}"""
+      ))
+    }
+  }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/CaseClassSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/CaseClassSupportSpec.scala
@@ -251,4 +251,19 @@ class CaseClassSupportSpec extends Spec {
       ))
     }
   }
+
+  class `A multi-level parameterized case class` {
+    @Test def `is parsable from a JSON object` = {
+      val c = parse[CaseClassWithParameter[List[CaseClassWithParameter[Int]]]]("""{"id":"1","list":[[{"id":"2","list":[3]}]]}""")
+
+      c.id.must(be(1))
+      c.list.must(be(List(List(CaseClassWithParameter[Int](2,List(3))))))
+    }
+
+    @Test def `generates a JSON object` = {
+      generate(CaseClassWithParameter[List[CaseClassWithParameter[Int]]](1,List(List(CaseClassWithParameter[Int](2,List(3)))))).must(be(
+        """{"id":1,"list":[[{"id":2,"list":[3]}]]}"""
+      ))
+    }
+  }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/ExampleCaseClasses.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/ExampleCaseClasses.scala
@@ -72,3 +72,5 @@ case class CaseClassWithTwoConstructors(id: Long,  name: String) {
 case class CaseClassWithSnakeCase(oneThing: String, twoThing: String)
 
 case class CaseClassWithArrays(one: String, two: Array[String], three: Array[Int])
+
+case class CaseClassWithParameter[T](id: Long, list: List[T])


### PR DESCRIPTION
This patch lets Jerkson work with parameterized case classes by extracting type parameters using javaType.containedType, stashing them in a Map, and passing them through to typeRef2JavaType. In turn, typeRef2JavaType will return the stashed JavaTypes if it encounters one of them instead of trying to load classes using a generic name (which leads to a ClassNotFoundException). The patch series also includes a couple of test cases.

There might be a nicer way to accomplish the same thing but I am not aware of one.
